### PR TITLE
Replace Yinit check to remove SyntaxWarning

### DIFF
--- a/trimap/trimap_.py
+++ b/trimap/trimap_.py
@@ -588,12 +588,12 @@ def trimap(
         if verbose:
             print("using stored triplets")
 
-    if Yinit is None or Yinit is "pca":
+    if not Yinit or Yinit == "pca":
         if pca_solution:
             Y = 0.01 * X[:, :n_dims]
         else:
             Y = 0.01 * PCA(n_components=n_dims).fit_transform(X).astype(np.float32)
-    elif Yinit is "random":
+    elif Yinit == "random":
         Y = np.random.normal(size=[n, n_dims]).astype(np.float32) * 0.0001
     else:
         Y = Yinit.astype(np.float32)


### PR DESCRIPTION
These changes are made to fix the python `SyntaxWarning`.

During trimap  installation, the following `SyntaxWarnings` are emitted:

```bash
/opt/conda/lib/python3.8/site-packages/trimap/trimap_.py:591: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if Yinit is None or Yinit is "pca":
/opt/conda/lib/python3.8/site-packages/trimap/trimap_.py:596: SyntaxWarning: "is" with a literal. Did you mean "=="?
  elif Yinit is "random":
```