### PR TITLE
fixes #23: assign initial coords

### DIFF
--- a/trimap/trimap_.py
+++ b/trimap/trimap_.py
@@ -588,7 +588,7 @@ def trimap(
         Y = Yinit.astype(np.float32)
     if return_seq:
         Y_all = np.zeros((n, n_dims, int(n_iters / _RETURN_EVERY + 1)))
-        Y_all[:, :, 0] = Yinit
+        Y_all[:, :, 0] = Y
 
     C = np.inf
     tol = 1e-7


### PR DESCRIPTION
This change fixes an issue with getting out the initial coordinates when `return_seq=True`.

To test:

```python
import trimap
from sklearn.datasets import load_digits

digits = load_digits()

embedding = trimap.TRIMAP(return_seq=True).fit_transform(digits.data, init="pca")
```

* This should now succeed and not raise a `ValueError`.
* `embedding[:, :, 0]` should *not* contain any `nan` values.

Also:

```python
embedding = trimap.TRIMAP(return_seq=True).fit_transform(digits.data)
```

should succeed and  `embedding[:, :, 0]` should also *not* contain any `nan` values.