### PR TITLE
remove setuptools as dependency

### DIFF
--- a/trimap/__init__.py
+++ b/trimap/__init__.py
@@ -1,5 +1,10 @@
 from .trimap_ import TRIMAP
 
-import pkg_resources
+from importlib.metadata import version, PackageNotFoundError
 
-__version__ = pkg_resources.get_distribution("trimap").version
+try:
+    __version__ = version('trimap')
+except PackageNotFoundError:
+    __version__ = "unknown"
+
+__all__ = ["TRIMAP"]


### PR DESCRIPTION
for python 3.8+, `setuptools` is no longer necessary to achieve version functionality.

right now if you do `pip install trimap` in a fresh venv (e.g. python 3.11), you'll find you cannot import it because of this `__init__.py` file.

this PR addresses the need for version inference using `importlib` directly.

thanks for the awesome work!